### PR TITLE
add notification 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="true"
@@ -31,6 +33,11 @@
         </service>
 
         <service android:name="com.bakapiano.maimai.updater.server.HttpServerService" />
+
+        <service android:name="com.bakapiano.maimai.updater.notification.NotificationUtil"
+            android:enabled="true">
+
+        </service>
 
     </application>
 

--- a/app/src/main/java/com/bakapiano/maimai/updater/crawler/WechatCrawler.java
+++ b/app/src/main/java/com/bakapiano/maimai/updater/crawler/WechatCrawler.java
@@ -2,17 +2,15 @@ package com.bakapiano.maimai.updater.crawler;
 
 import static com.bakapiano.maimai.updater.crawler.CrawlerCaller.writeLog;
 
-import android.os.Build;
 import android.util.Log;
 
-import org.jetbrains.annotations.NotNull;
+import com.bakapiano.maimai.updater.notification.NotificationUtil;
 
 import java.io.IOException;
 import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -30,7 +28,6 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
 import okhttp3.Call;
-import okhttp3.Callback;
 import okhttp3.ConnectionSpec;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
@@ -193,6 +190,7 @@ public class WechatCrawler {
 
         // TODO: Fetch chuithm data
         // this.fetchChunithmData(username, password);
+        NotificationUtil.getINSTANCE().stopNotification();
     }
 
     protected String getLatestVersion() {

--- a/app/src/main/java/com/bakapiano/maimai/updater/notification/NotificationUtil.java
+++ b/app/src/main/java/com/bakapiano/maimai/updater/notification/NotificationUtil.java
@@ -1,0 +1,107 @@
+package com.bakapiano.maimai.updater.notification;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.BitmapFactory;
+import android.os.Build;
+import android.os.IBinder;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import com.bakapiano.maimai.updater.R;
+import com.bakapiano.maimai.updater.ui.MainActivity;
+
+public class NotificationUtil extends Service {
+
+    private volatile static NotificationUtil INSTANCE;
+    private Context mContext;
+    private static final String TAG = "notification";
+    public static NotificationUtil getINSTANCE() {
+        if (INSTANCE == null) {
+            synchronized (NotificationUtil.class) {
+                if (INSTANCE == null) {
+                    INSTANCE = new NotificationUtil();
+                }
+            }
+        }
+        return INSTANCE;
+    }
+
+    public NotificationUtil() {
+    }
+
+    public NotificationUtil setContext(Context mContext) {
+        Log.d(TAG, "setContext: "+mContext);
+        this.mContext = mContext;
+        return getINSTANCE();
+    }
+
+    public void startNotification() {
+        Log.d(TAG, "startNotification: "+ mContext);
+        Intent notificationIntent = new Intent(mContext, this.getClass());
+        mContext.startService(notificationIntent);
+    }
+    public void stopNotification() {
+        Intent notificationIntent = new Intent(mContext, this.getClass());
+        mContext.stopService(notificationIntent);
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        createNotificationChannel();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        stopForeground(true);
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        return START_STICKY;
+    }
+
+    private void createNotificationChannel() {
+        Notification.Builder builder = new Notification.Builder(getApplicationContext());
+        Intent nfIntent = new Intent(this, MainActivity.class);
+        nfIntent.setAction(Intent.ACTION_MAIN);
+        nfIntent.addCategory(Intent.CATEGORY_LAUNCHER);
+        nfIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+        builder.setContentIntent(PendingIntent.getActivity(this, 0, nfIntent, PendingIntent.FLAG_IMMUTABLE))
+                .setLargeIcon(BitmapFactory.decodeResource(getResources(), R.mipmap.ic_launcher))
+                .setContentTitle("更新器后台运行通知")
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setContentText("正在努力的帮你上传分数")
+                .setWhen(System.currentTimeMillis());
+
+        /*以下是对Android 8.0的适配*/
+        //普通notification适配
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+
+            builder.setChannelId("updater_keep_alive_channel");
+            NotificationManager notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+            NotificationChannel channel = new NotificationChannel("updater_keep_alive_channel", "更新器后台运行通知", NotificationManager.IMPORTANCE_LOW);
+            notificationManager.createNotificationChannel(channel);
+        }
+
+        Notification notification = builder.build();
+        notification.defaults = Notification.DEFAULT_SOUND;
+        startForeground(12001,notification);
+
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+
+}

--- a/app/src/main/java/com/bakapiano/maimai/updater/ui/MainActivity.java
+++ b/app/src/main/java/com/bakapiano/maimai/updater/ui/MainActivity.java
@@ -41,6 +41,7 @@ import java.util.Random;
 import com.bakapiano.maimai.updater.R;
 import com.bakapiano.maimai.updater.crawler.Callback;
 import com.bakapiano.maimai.updater.crawler.CrawlerCaller;
+import com.bakapiano.maimai.updater.notification.NotificationUtil;
 import com.bakapiano.maimai.updater.server.HttpServer;
 import com.bakapiano.maimai.updater.server.HttpServerService;
 import com.bakapiano.maimai.updater.vpn.core.Constant;
@@ -185,6 +186,7 @@ public class MainActivity extends AppCompatActivity implements
         if (LocalVpnService.IsRunning != isChecked) {
             switchProxy.setEnabled(false);
             if (isChecked) {
+                NotificationUtil.getINSTANCE().setContext(this).startNotification();
                 checkProberAccount(result -> {
                     this.runOnUiThread(() -> {
                         if ((Boolean) result) {


### PR DESCRIPTION
for keep alive and prevent background caused connection abort
保活 也是高版本Android要求 本来代理开在后台服务就要有个通知（
顺便解决了software caused connection abort
测试在登录成功后一直停留在微信界面 分数上传成功
备注：a13 可能要手动申请通知权限